### PR TITLE
Autoconf

### DIFF
--- a/nemesys.iss
+++ b/nemesys.iss
@@ -76,7 +76,7 @@ Filename: {sys}\netsh.exe; Parameters: " int ip set global taskoffload=disabled"
 Filename: {sys}\netsh.exe; Parameters: " firewall add allowedprogram ""{app}\dist\winservice.exe"" ""Nemesys"" ENABLE CUSTOM 193.104.137.0/24 ALL"; Description: "Enable Nemesys traffic"; Flags: RunHidden RunAsCurrentUser; 
 Filename: {sys}\netsh.exe; Parameters: " firewall add allowedprogram ""{app}\dist\login.exe"" ""Nemesys"" ENABLE CUSTOM 193.104.137.0/24 ALL"; Description: "Enable Nemesys login"; Flags: RunHidden RunAsCurrentUser; 
 ;Filename: {sys}\netsh.exe; Parameters: " advfirewall firewall add rule name=""Nemesys"" dir=out action=allow program=""{app}\dist\Nemesys.exe"" enable=yes"; Description: "Enable Nemesys traffic"; Flags: RunHidden RunAsCurrentUser; MinVersion: ,6.1.7600; 
-Filename: {app}\dist\login.exe; Parameters: "{""srcexe""}"; Description: "Autenticazione per il servizio Nemesys."; StatusMsg: "Autenticazione per il servizio Nemesys"; Flags: RunHidden RunAsCurrentUser;
+Filename: {app}\dist\login.exe; Parameters: """{srcexe}"""; Description: "Autenticazione per il servizio Nemesys."; StatusMsg: "Autenticazione per il servizio Nemesys"; Flags: RunHidden RunAsCurrentUser;
 Filename: {app}\dist\Nemesys.exe; Parameters: "--startup auto install"; Description: "Installazione del servizio Nemesys."; StatusMsg: "Installazione del servizio Nemesys"; Flags: RunHidden RunAsCurrentUser; 
 Filename: {app}\dist\Nemesys.exe; Parameters: start; Description: "Avvia il servizio Nemesys"; Flags: PostInstall RunHidden RunAsCurrentUser; StatusMsg: "Avvia il servizio Nemesys"; 
  

--- a/nemesys.iss
+++ b/nemesys.iss
@@ -76,7 +76,7 @@ Filename: {sys}\netsh.exe; Parameters: " int ip set global taskoffload=disabled"
 Filename: {sys}\netsh.exe; Parameters: " firewall add allowedprogram ""{app}\dist\winservice.exe"" ""Nemesys"" ENABLE CUSTOM 193.104.137.0/24 ALL"; Description: "Enable Nemesys traffic"; Flags: RunHidden RunAsCurrentUser; 
 Filename: {sys}\netsh.exe; Parameters: " firewall add allowedprogram ""{app}\dist\login.exe"" ""Nemesys"" ENABLE CUSTOM 193.104.137.0/24 ALL"; Description: "Enable Nemesys login"; Flags: RunHidden RunAsCurrentUser; 
 ;Filename: {sys}\netsh.exe; Parameters: " advfirewall firewall add rule name=""Nemesys"" dir=out action=allow program=""{app}\dist\Nemesys.exe"" enable=yes"; Description: "Enable Nemesys traffic"; Flags: RunHidden RunAsCurrentUser; MinVersion: ,6.1.7600; 
-Filename: {app}\dist\login.exe; Parameters: "{srcexe}"; Description: "Autenticazione per il servizio Nemesys."; StatusMsg: "Autenticazione per il servizio Nemesys"; Flags: RunHidden RunAsCurrentUser;
+Filename: {app}\dist\login.exe; Parameters: "{""srcexe""}"; Description: "Autenticazione per il servizio Nemesys."; StatusMsg: "Autenticazione per il servizio Nemesys"; Flags: RunHidden RunAsCurrentUser;
 Filename: {app}\dist\Nemesys.exe; Parameters: "--startup auto install"; Description: "Installazione del servizio Nemesys."; StatusMsg: "Installazione del servizio Nemesys"; Flags: RunHidden RunAsCurrentUser; 
 Filename: {app}\dist\Nemesys.exe; Parameters: start; Description: "Avvia il servizio Nemesys"; Flags: PostInstall RunHidden RunAsCurrentUser; StatusMsg: "Avvia il servizio Nemesys"; 
  

--- a/nemesys/login.py
+++ b/nemesys/login.py
@@ -317,10 +317,10 @@ def extract_autoconf_credentials():
     _, filename = os.path.split(file_path)
     name, ext = os.path.splitext(filename)
     components = name.split('@')
-    if len(components) != 3:
+    if len(components) != 3 and len(components) != 4:
         logger.info('Pacchetto non autoconfigurante')
         return None
-    nemesys, client_type, token = components
+    nemesys, client_type, token = components[:3]
     logger.info(f'Pacchetto autoconfigurante: tipo client {client_type}, token {token}')
     return client_type, token
 


### PR DESCRIPTION
Bugfix autoconfigurazione: spazi nel percorso dell'installer erano interpretati come separatori di parametri.

Aggiunta la possibilità di inserire una ulteriore chiocciola alla fine del nome del file, per preservare il token in caso di aggiunta automatica di suffissi aggiunti automaticamente al nome