### PR TITLE
Fix ambiente di test e build Windows

### DIFF
--- a/common/paths.py
+++ b/common/paths.py
@@ -41,23 +41,11 @@ _CONF_DIR = path.join(_APP_PATH, 'config')
 LOG_DIR = path.join(_APP_PATH, 'logs')
 NEMESYS_LOG_FILE = path.join(LOG_DIR, 'nemesys.log')
 NEMESYS_PID_FILE = '/var/run/nemesys_daemon.pid'
-MIST_LOG_FILE = path.join(LOG_DIR, 'misurainternet-speedtest.log')
-
 CONF_LOG = path.join(_CONF_DIR, 'log.conf')
 CONF_MAIN = path.join(_CONF_DIR, 'client.conf')
 
-# Resources path
-if utils.is_darwin():
-    ICONS = path.join(_APP_PATH, 'Resources', 'icons')
-else:
-    ICONS = path.join(_APP_PATH, 'mist', 'resources', 'icons')
-
 def create_nemesys_dirs():
     create_dirs(dirs=[LOG_DIR, OUTBOX_DIR, SENT_DIR, _CONF_DIR])
-
-
-def create_mist_dirs():
-    create_dirs(dirs=[LOG_DIR, OUTBOX_DIR, _CONF_DIR])
 
 
 def create_dirs(dirs=[]):

--- a/nemesys.iss
+++ b/nemesys.iss
@@ -77,7 +77,7 @@ Filename: {sys}\netsh.exe; Parameters: " firewall add allowedprogram ""{app}\dis
 Filename: {sys}\netsh.exe; Parameters: " firewall add allowedprogram ""{app}\dist\login.exe"" ""Nemesys"" ENABLE CUSTOM 193.104.137.0/24 ALL"; Description: "Enable Nemesys login"; Flags: RunHidden RunAsCurrentUser; 
 ;Filename: {sys}\netsh.exe; Parameters: " advfirewall firewall add rule name=""Nemesys"" dir=out action=allow program=""{app}\dist\Nemesys.exe"" enable=yes"; Description: "Enable Nemesys traffic"; Flags: RunHidden RunAsCurrentUser; MinVersion: ,6.1.7600; 
 Filename: {app}\dist\login.exe; Parameters: """{srcexe}"""; Description: "Autenticazione per il servizio Nemesys."; StatusMsg: "Autenticazione per il servizio Nemesys"; Flags: RunHidden RunAsCurrentUser;
-Filename: {app}\dist\Nemesys.exe; Parameters: "--startup auto install"; Description: "Installazione del servizio Nemesys."; StatusMsg: "Installazione del servizio Nemesys"; Flags: RunHidden RunAsCurrentUser; 
+Filename: {app}\dist\Nemesys.exe; Parameters: "install"; Description: "Installazione del servizio Nemesys."; StatusMsg: "Installazione del servizio Nemesys"; Flags: RunHidden RunAsCurrentUser;
 Filename: {app}\dist\Nemesys.exe; Parameters: start; Description: "Avvia il servizio Nemesys"; Flags: PostInstall RunHidden RunAsCurrentUser; StatusMsg: "Avvia il servizio Nemesys"; 
  
 [UninstallRun]

--- a/nemesys/Nemesys.py
+++ b/nemesys/Nemesys.py
@@ -27,81 +27,74 @@ except ImportError:
 import logging
 import os
 import sys
-import time
-from threading import Thread
+from threading import Thread, Event
 
 from nemesys import executer
 
-###  DISCOVERING PATH  ###
+### Rilevamento del path dell'eseguibile ###
+# sys.argv[0] punta all'exe compilato da py2exe; usato per scrivere il log
+# nella stessa cartella dell'eseguibile.
 try:
     _PATH = os.path.dirname(sys.argv[0])
     if _PATH == '':
         _PATH = "." + os.sep
     if _PATH[len(_PATH) - 1] != os.sep:
         _PATH = _PATH + os.sep
-except Exception as e:
+except Exception:
     _PATH = "." + os.sep
 
+### Logging ###
+# Log dedicato al wrapper del servizio Windows, separato dal log di executer.
+# time non è necessario: i timestamp sono gestiti internamente da logging.Formatter.
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+_fh = logging.FileHandler(_PATH + 'log_nemesys.log')
+_fh.setLevel(logging.DEBUG)
+_fh.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+logger.addHandler(_fh)
+logger.info('PATH: %s', _PATH)
 
-### Logging Functionality ###
-# quando esegui da linea di comando il file di prop e' in C:\Python26\Lib\site-packages\win32\cfg !!
-nemesys = logging.getLogger("nemesys")
-nemesys.setLevel(logging.DEBUG)
-fh1 = logging.FileHandler(_PATH + 'log_nemesys.log')
-fh1.setLevel(logging.DEBUG)
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-fh1.setFormatter(formatter)
-nemesys.addHandler(fh1)
-nemesys.info('PATH: ' + _PATH)
 
-
-### Executer Thread ###
+### Thread che esegue il loop principale di Nemesys ###
 class execThread(Thread):
     def __init__(self):
         Thread.__init__(self)
-        self.pid = os.getpid()
+        # daemon=True: il thread viene terminato automaticamente quando il
+        # processo principale esce, senza bisogno di un kill esplicito.
+        self.daemon = True
 
     def run(self):
         executer.main()
 
-### Service Running ###
 
-
+### Definizione del servizio Windows ###
 class aservice(win32serviceutil.ServiceFramework):
     _svc_name_ = "NeMeSys"
     _svc_display_name_ = "NeMeSys Service"
     _svc_description_ = "Sistema per la valutazione della connessione broadband"
+    # Avvio automatico: dichiarato nella classe così che bastı "install" senza
+    # "--startup auto", evitando la ChangeServiceConfig che falliva su py2exe.
+    _svc_start_type_ = win32service.SERVICE_AUTO_START
 
     def __init__(self, args):
         win32serviceutil.ServiceFramework.__init__(self, args)
-        self.isAlive = True
+        self._stop_event = Event()
 
     def SvcDoRun(self):
         servicemanager.LogInfoMsg("NeMeSys Service - started")
+        # Notifica al SCM che il servizio è in esecuzione prima di bloccarsi.
+        self.ReportServiceStatus(win32service.SERVICE_RUNNING)
         ex = execThread()
         ex.start()
-        pid = ex.pid
-        servicemanager.LogInfoMsg("NeMeSys Service - executer started - " + str(pid))
-        i = 1
-        while self.isAlive:
-            # Aspetta il segnale di stop per il tempo di timeout (30 secs)
-            #rc = win32event.WaitForSingleObject(self.hWaitStop, 30000)
-            time.sleep(1)
-            i += 0
-            #servicemanager.LogInfoMsg("NeMeSys Service Up&Running")
-
-        if self.isAlive is False:
-            # Stop Signal received
-            servicemanager.LogInfoMsg("NeMeSys Service Stopped")
-            # disalloco la memoria COM prima di uccidere il processo
-            # ex.couni()
-            os.popen('taskkill /pid ' + str(pid))
+        servicemanager.LogInfoMsg("NeMeSys Service - executer started")
+        # Attende il segnale di stop senza busy-wait.
+        self._stop_event.wait()
+        servicemanager.LogInfoMsg("NeMeSys Service - stopped")
 
     def SvcStop(self):
-        servicemanager.LogInfoMsg("Stopping NeMeSys Service - stop signal received ")
+        servicemanager.LogInfoMsg("NeMeSys Service - stop signal received")
         self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
-        self.isAlive = False
-        # win32event.SetEvent(self.hWaitStop)
+        self._stop_event.set()
 
     SvcShutdown = SvcStop
 
@@ -110,22 +103,15 @@ def ctrlHandler(ctrlType):
     return True
 
 
-def mainArg(argv):
-    if len(argv) == 1:
-        start = 'start'
-        sys.argv.append(start)
-        es = os.popen('Net START EventSystem').read()
-        nemesys.info('Starting EventSystem - %s', es)
-    elif 'start' in argv:
-        es = os.popen('Net START EventSystem').read()
-        nemesys.info('Starting EventSystem - %s', es)
-    elif 'restart' in argv:
-        es = os.popen('Net START EventSystem').read()
-        nemesys.info('Starting EventSystem - %s', es)
-
-
+### Entry point ###
 if __name__ == '__main__':
-    mainArg(sys.argv)
-    # Lancio il servizio Nemesys
-    win32api.SetConsoleCtrlHandler(ctrlHandler, True)
-    win32serviceutil.HandleCommandLine(aservice)
+    if len(sys.argv) == 1:
+        # Lanciato dal SCM (Service Control Manager): avvia il dispatcher.
+        # Pattern corretto per eseguibili py2exe con pywin32.
+        servicemanager.Initialize()
+        servicemanager.PrepareToHostSingle(aservice)
+        servicemanager.StartServiceCtrlDispatcher()
+    else:
+        # Lanciato da riga di comando (install / start / stop / remove).
+        win32api.SetConsoleCtrlHandler(ctrlHandler, True)
+        win32serviceutil.HandleCommandLine(aservice)

--- a/nemesys/executer.py
+++ b/nemesys/executer.py
@@ -400,8 +400,8 @@ def main():
     restart_scheduler = restart.RestartScheduler()
     restart_scheduler.start()
 
-    if utils.is_linux():
-        logger.debug("Inizio il loop.")
+    if utils.is_windows():
+        # La daemonizzazione è gestita da Nemesys.py tramite il servizio Windows.
         e.loop()
     else:
         logger.info("Avvio il demone Nemesys")
@@ -412,8 +412,6 @@ def main():
             pidfile=pidf,
             files_preserve=log_streams,
         )
-        # TODO: context.signal_map = {signal.SIGTERM: do_exit}
-        # But need to fix sleep wakeup etc first
         with context:
             e.loop()
             logger.info("Loop exit")

--- a/nemesys/executer_test.py
+++ b/nemesys/executer_test.py
@@ -68,12 +68,19 @@ class MockScheduler(object):
         self._tasks = [self.task_default, self.task_wait]
         self._i = -1
 
-    def download_task(self):
-        #         return self.task_wait
+    def download_task(self, **kwargs):
         self._i += 1
         if self._i == len(self._tasks):
             self._i = 0
         return self._tasks[self._i]
+
+
+class MockChooser(object):
+    def __init__(self, server):
+        self._server = server
+
+    def choose_server(self, _callback):
+        return self._server
 
 
 class MockDeliverer(object):
@@ -120,7 +127,9 @@ def main():
                   c.isp.certificate,
                   options.httptimeout)
     scheduler = MockScheduler()
+    chooser = MockChooser(scheduler.task_default.server)
     exe = Executer(client=c,
+                   chooser=chooser,
                    scheduler=scheduler,
                    deliverer=d,
                    sys_profiler=sys_profiler,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-daemon==2.3.0; sys_platform == 'win32'
+python-daemon==2.3.0; sys_platform != 'win32'
 pywin32==303; sys_platform == 'win32'
 py2exe==0.11.1.0; sys_platform == 'win32'
 py2app==0.27; sys_platform == 'darwin'

--- a/setup_mac.py
+++ b/setup_mac.py
@@ -52,25 +52,6 @@ version = get_version()
 print("version: ", version)
 
 COPYRIGHT = 'Copyright 2012-2017 Fondazione Ugo Bordoni'
-APP_MIST = ['mist/mist_main.py']
-APP_NAME_MIST = 'Mist'
-DATA_FILES_MIST = ['mist/mist_main.py']
-OPTIONS_MIST = {'argv_emulation': True,
-                # 'plist': 'Info_mist.plist',
-                'plist': {
-                    'CFBundlePackageType': 'APPL',
-                    'CFBundleName': APP_NAME_MIST,
-                    'CFBundleDisplayName': APP_NAME_MIST,
-                    'CFBundleIdentifier': 'it.fub.mist',
-                    'CFBundleVersion': version,
-                    'CFBundleShortVersionString': version,
-                    'NSHumanReadableCopyright': COPYRIGHT,
-                    'CFBundleIconFile': 'icons/mist.icns'
-                },
-                'resources': 'mist/resources/icons',
-                'iconfile': 'icons/mist.icns',
-                'semi_standalone': False,
-                }
 
 APP_EXECUTER = ['nemesys/executer.py']
 APP_NAME_EXECUTER = 'executer'
@@ -92,27 +73,9 @@ OPTIONS_EXECUTER = {'argv_emulation': True,
                     'extra_scripts': 'nemesys/login.py',
                     }
 
-# Hitch hike on sys.argv to choose which target to build,
-# then remove it to avoid errors in py2app
-target = 'nemesys'
-if len(sys.argv) >= 3:
-    target = sys.argv[len(sys.argv) - 1]
-    if target in ('mist', 'nemesys'):
-        del sys.argv[len(sys.argv) - 1]
-
-if target == 'mist':
-    setup(
-        app=APP_MIST,
-        name='Mist',
-        version='%s' % version,
-        data_files=DATA_FILES_MIST,
-        options={'py2app': OPTIONS_MIST},
-        setup_requires=['py2app'],
-    )
-else:
-    setup(
-        app=APP_EXECUTER,
-        data_files=DATA_FILES,
-        options={'py2app': OPTIONS_EXECUTER},
-        setup_requires=['py2app'],
-    )
+setup(
+    app=APP_EXECUTER,
+    data_files=DATA_FILES,
+    options={'py2app': OPTIONS_EXECUTER},
+    setup_requires=['py2app'],
+)

--- a/setup_win.py
+++ b/setup_win.py
@@ -72,7 +72,7 @@ setup(
     data_files=data_files,
     options={
         'py2exe': {
-            'packages': ['encodings', 'common', 'nemesys'],
+            'packages': ['encodings', 'common', 'nemesys', 'charset_normalizer'],
             'includes': ['_cffi_backend'],
             'optimize': 2,
         }

--- a/setup_win.py
+++ b/setup_win.py
@@ -73,6 +73,7 @@ setup(
     options={
         'py2exe': {
             'packages': ['encodings', 'common', 'nemesys'],
+            'includes': ['_cffi_backend'],
             'optimize': 2,
         }
     },

--- a/setup_win.py
+++ b/setup_win.py
@@ -9,7 +9,6 @@ from distutils.core import setup
 from glob import glob
 
 sys.path.append('C:\\Microsoft.VC90.CRT')
-sys.path.append(os.path.join('.', 'mist'))
 sys.path.append(os.path.join('.', 'nemesys'))
 sys.path.append(os.path.join('.', 'common'))
 
@@ -29,7 +28,6 @@ def get_version():
             break
 
     # Fix version in Inno Setup file too!
-    sub_iss_file(os.path.join('.', 'mist.iss'), ver)
     sub_iss_file(os.path.join('.', 'nemesys.iss'), ver)
 
     return ver

--- a/setup_win.py
+++ b/setup_win.py
@@ -72,7 +72,7 @@ setup(
     data_files=data_files,
     options={
         'py2exe': {
-            'packages': 'encodings',
+            'packages': ['encodings', 'common', 'nemesys'],
             'optimize': 2,
         }
     },


### PR DESCRIPTION
- executer_test.py: aggiunto MockChooser e parametro chooser alla costruzione di Executer, allineando la firma con quella attuale della classe. Aggiornato download_task per accettare **kwargs. Corretta la condizione di installazione di python-daemon in requirements.txt (era limitata a Windows, ora esclusa solo su Windows).
- Pulizia riferimenti a MIST: rimossi da setup_win.py, setup_mac.py e common/paths.py tutti i riferimenti alla generazione del pacchetto MIST (variabili, target di build, path, costanti di log e funzioni inutilizzate).
- Build Windows (setup_win.py): aggiunti i package common, nemesys e charset_normalizer alla configurazione py2exe per risolvere errori di moduli mancanti a runtime. Aggiunto _cffi_backend agli includes per risolvere la dipendenza C di cryptography.
- Servizio Windows (Nemesys.py): riscritto con il pattern corretto per py2exe + pywin32. Aggiunto _svc_start_type_ = SERVICE_AUTO_START nella classe del servizio per evitare la ChangeServiceConfig che falliva. Sostituito il busy-wait con threading.Event. Aggiunto ReportServiceStatus(SERVICE_RUNNING). Rimosso os.popen('taskkill').
- executer.py: corretto il branch di avvio del demone: su Windows viene chiamato e.loop() direttamente (la daemonizzazione è gestita dal servizio), su Linux e Mac viene usato il daemon context di python-daemon come previsto.